### PR TITLE
Ignoring the children of manifest assets when using cspAssetRegex

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This `CspHtmlWebpackPlugin` accepts 2 params with the following structure:
 
 This plugin also adds another option to the `HtmlWebpackPlugin`
 * `{RegExp}` cspAssetRegex (optional) - if defined, only assets which match the regex will be hashed and added to the policy. Dependencies of these assets will also be added to the policy regardless of whether they match the regex or not.
+  * Note: If you are using a manifest plugin, you should make sure your manifest asset is matched in this regex as well
 
 #### Default Policy:
 

--- a/plugin.js
+++ b/plugin.js
@@ -98,6 +98,8 @@ class CspHtmlWebpackPlugin {
     const matchedChunkIds = [];
     const seenChunkId = [];
 
+    let manifestChunkId = -1;
+
     statsJsonChunks.forEach(chunk => {
       if (typeof chunk.id !== 'undefined') {
         // add all chunks into a parent child map
@@ -108,6 +110,11 @@ class CspHtmlWebpackPlugin {
           } else {
             parentChildChunkRelationship[parent].push(chunk.id.toString());
           }
+        }
+
+        // if the chunk size is 0 right now, it's probably the empty manifest chunk - let's mark it as such
+        if (chunk.size === 0) {
+          manifestChunkId = chunk.id;
         }
 
         // match filenames we want to hash
@@ -132,9 +139,11 @@ class CspHtmlWebpackPlugin {
         this.addToHashesArray(filename, compilationAssets);
       });
 
+      // if we have children to iterate, and we're not currently on the manifest chunk, iterate through them
       if (
         typeof parentChildChunkRelationship[chunkId] !== 'undefined' &&
-        parentChildChunkRelationship[chunkId].length > 0
+        parentChildChunkRelationship[chunkId].length > 0 &&
+        chunkId !== manifestChunkId
       ) {
         for (
           let i = 0, len = parentChildChunkRelationship[chunkId].length;


### PR DESCRIPTION
###  Summary

Currently, if you pull in the manifest asset, it's children are defined as all of the other assets in the build.
This causes the plugin to hash *all* assets in the build, rather than only the smaller subset that the developer has defined using the `cspAssetRegex` option.

This change ignores the children of the manifest asset when recursively iterating through the assets to hash

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
