### PR TITLE
Making sure that apostropes are preserved

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@ Describe the goal of this PR. Mention any related Issue numbers.
 * [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/contributing.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
 * [ ] I've written tests to cover the new code and functionality included in this PR.
-* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
+* [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).

--- a/plugin.js
+++ b/plugin.js
@@ -77,7 +77,9 @@ class CspHtmlWebpackPlugin {
       compilation.plugin(
         'html-webpack-plugin-after-html-processing',
         (htmlPluginData, compileCb) => {
-          const $ = cheerio.load(htmlPluginData.html);
+          const $ = cheerio.load(htmlPluginData.html, {
+            decodeEntities: false
+          });
 
           // if not enabled, remove the empty tag
           if (!this.opts.enabled) {


### PR DESCRIPTION
###  Summary

Making sure that apostropes are preserved as cheerio was escaping them

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
