### PR TITLE
Hashing the html instead of just the text

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -94,10 +94,10 @@ class CspHtmlWebpackPlugin {
           const policyObj = JSON.parse(JSON.stringify(this.policy));
 
           const inlineSrc = $('script:not([src])')
-            .map((i, element) => this.hash($(element).text()))
+            .map((i, element) => this.hash($(element).html()))
             .get();
           const inlineStyle = $('style:not([href])')
-            .map((i, element) => this.hash($(element).text()))
+            .map((i, element) => this.hash($(element).html()))
             .get();
 
           policyObj['script-src'] = policyObj['script-src'].concat(inlineSrc);

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -87,7 +87,7 @@ describe('CspHtmlWebpackPlugin', () => {
         const expected =
           "base-uri 'self';" +
           " object-src 'none';" +
-          " script-src 'unsafe-inline' 'self' 'unsafe-eval' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=';" +
+          " script-src 'unsafe-inline' 'self' 'unsafe-eval' 'sha256-9nPWXYBnlIeJ9HmieIATDv9Ab5plt35XZiT48TfEkJI=';" +
           " style-src 'unsafe-inline' 'self' 'unsafe-eval'";
 
         expect(cspPolicy).toEqual(expected);
@@ -123,7 +123,7 @@ describe('CspHtmlWebpackPlugin', () => {
           "base-uri 'self';" +
           " object-src 'none';" +
           " script-src 'unsafe-inline' 'self' 'unsafe-eval';" +
-          " style-src 'unsafe-inline' 'self' 'unsafe-eval' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='";
+          " style-src 'unsafe-inline' 'self' 'unsafe-eval' 'sha256-MqG77yUiqBo4MMVZAl09WSafnQY4Uu3cSdZPKxaf9sQ='";
 
         expect(cspPolicy).toEqual(expected);
 


### PR DESCRIPTION
###  Summary

Hashing the html instead of just the text to make sure we get the correct sha hash required 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).
