### PR TITLE
Allowing enabled to accept a function as well as a boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This `CspHtmlWebpackPlugin` accepts 2 params with the following structure:
 * `{object}` Policy (optional) - a flat object which defines your CSP policy. Valid keys and values can be found on the [MDN CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) page. Values can either be a string or an array of strings.
 * `{object}` Additional Options (optional) - a flat object with the optional configuration options:
   * `{string}` hashingMethod - accepts 'sha256', 'sha384', 'sha512' - your node version must also accept this hashing method.
-  * `{boolean}` enabled - if false, the empty CSP tag will be stripped from the html output
+  * `{boolean|Function}` enabled - if false, or the function returns false, the empty CSP tag will be stripped from the html output. The `htmlPluginData` is passed into the function as it's first param.
 
 #### Default Policy:
 

--- a/plugin.js
+++ b/plugin.js
@@ -2,6 +2,7 @@ const cheerio = require('cheerio');
 const crypto = require('crypto');
 const uniq = require('lodash/uniq');
 const compact = require('lodash/compact');
+const isFunction = require('lodash/isFunction');
 
 const defaultPolicy = {
   'base-uri': "'self'",
@@ -34,6 +35,19 @@ class CspHtmlWebpackPlugin {
         `'${this.opts.hashingMethod}' is not a valid hashing method`
       );
     }
+  }
+
+  /**
+   * Checks to see whether the plugin is enabled. this.opts.enabled can be a function or bool here
+   * @param htmlPluginData - the htmlPluginData from compilation
+   * @return {boolean} - whether the plugin is enabled or not
+   */
+  isEnabled(htmlPluginData) {
+    if (isFunction(this.opts.enabled)) {
+      return this.opts.enabled(htmlPluginData);
+    }
+
+    return this.opts.enabled;
   }
 
   /**
@@ -82,7 +96,7 @@ class CspHtmlWebpackPlugin {
           });
 
           // if not enabled, remove the empty tag
-          if (!this.opts.enabled) {
+          if (!this.isEnabled(htmlPluginData)) {
             $('meta[http-equiv="Content-Security-Policy"]').remove();
 
             // eslint-disable-next-line no-param-reassign

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -174,7 +174,7 @@ describe('CspHtmlWebpackPlugin', () => {
     );
   });
 
-  it('removes the empty Content Security Policy meta tag if enabled is false', done => {
+  it('removes the empty Content Security Policy meta tag if enabled is the bool false', done => {
     const webpackConfig = {
       entry: path.join(__dirname, 'fixtures/index.js'),
       output: {
@@ -191,6 +191,40 @@ describe('CspHtmlWebpackPlugin', () => {
           {},
           {
             enabled: false
+          }
+        )
+      ]
+    };
+
+    testCspHtmlWebpackPlugin(
+      webpackConfig,
+      'index.html',
+      (cspPolicy, $, doneFn) => {
+        expect(cspPolicy).toBeUndefined();
+        expect($('meta').length).toEqual(1);
+        doneFn();
+      },
+      done
+    );
+  });
+
+  it('removes the empty Content Security Policy meta tag if enabled is a function which return false', done => {
+    const webpackConfig = {
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index.bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          filename: path.join(OUTPUT_DIR, 'index.html'),
+          template: path.join(__dirname, 'fixtures', 'with-nothing.html'),
+          inject: 'body'
+        }),
+        new CspHtmlWebpackPlugin(
+          {},
+          {
+            enabled: () => false
           }
         )
       ]


### PR DESCRIPTION
###  Summary

This will allow the `enabled` property to accept a function - this will allow conditionally turning on and off the CSP plugin for different HTMLWebpackPlugin compilations in the same webpack config file.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).
