### PR TITLE
Allow string values for script- and style-src policies

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -2,6 +2,7 @@ const cheerio = require('cheerio');
 const crypto = require('crypto');
 const uniq = require('lodash/uniq');
 const compact = require('lodash/compact');
+const flatten = require('lodash/flatten');
 const isFunction = require('lodash/isFunction');
 
 const defaultPolicy = {
@@ -114,8 +115,13 @@ class CspHtmlWebpackPlugin {
             .map((i, element) => this.hash($(element).html()))
             .get();
 
-          policyObj['script-src'] = policyObj['script-src'].concat(inlineSrc);
-          policyObj['style-src'] = policyObj['style-src'].concat(inlineStyle);
+          // Wrapped in flatten([]) to handle both when policy is a string and an array
+          policyObj['script-src'] = flatten([policyObj['script-src']]).concat(
+            inlineSrc
+          );
+          policyObj['style-src'] = flatten([policyObj['style-src']]).concat(
+            inlineStyle
+          );
 
           $('meta[http-equiv="Content-Security-Policy"]').attr(
             'content',

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -306,13 +306,13 @@ describe('CspHtmlWebpackPlugin', () => {
         new HtmlWebpackPlugin({
           filename: path.join(OUTPUT_DIR, 'index.html'),
           template: path.join(__dirname, 'fixtures', 'with-js.html'),
-          inject: 'body',
+          inject: 'body'
         }),
         new CspHtmlWebpackPlugin({
           'script-src': "'self'",
-          'style-src': "'self'",
-        }),
-      ],
+          'style-src': "'self'"
+        })
+      ]
     };
 
     testCspHtmlWebpackPlugin(

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -297,4 +297,39 @@ describe('CspHtmlWebpackPlugin', () => {
       );
     }).toThrow(new Error(`'invalid' is not a valid hashing method`));
   });
+
+  it('handles string values for policies where the hash is appended', done => {
+    const webpackConfig = {
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: { path: OUTPUT_DIR, filename: 'index.bundle.js' },
+      plugins: [
+        new HtmlWebpackPlugin({
+          filename: path.join(OUTPUT_DIR, 'index.html'),
+          template: path.join(__dirname, 'fixtures', 'with-js.html'),
+          inject: 'body',
+        }),
+        new CspHtmlWebpackPlugin({
+          'script-src': "'self'",
+          'style-src': "'self'",
+        }),
+      ],
+    };
+
+    testCspHtmlWebpackPlugin(
+      webpackConfig,
+      'index.html',
+      (cspPolicy, _, doneFn) => {
+        const expected =
+          "base-uri 'self';" +
+          " object-src 'none';" +
+          " script-src 'self' 'sha256-9nPWXYBnlIeJ9HmieIATDv9Ab5plt35XZiT48TfEkJI=';" +
+          " style-src 'self'";
+
+        expect(cspPolicy).toEqual(expected);
+
+        doneFn();
+      },
+      done
+    );
+  });
 });


### PR DESCRIPTION
###  Summary

Ensure that the script- and style-src found on the `policyObj` are indeed arrays before applying `Array.prototype.concat`. 

This is necessary because `"'self'".concat("'sha256-xx'")` evaluates to `'self''sha256-xx'`, which is an invalid policy. The same bug does not appear when using an array, because `buildPolicy` joins each item in the array with a space between, while it leaves strings intact.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).

I was unable to sign the CLA using the link provided, it just showed a blank page for me.
