### PR TITLE
Add option to skip hashing if unsafe-inline is present

### DIFF
--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -177,6 +177,94 @@ describe('CspHtmlWebpackPlugin', () => {
     );
   });
 
+  describe("when the user-specified script-src policy contains 'unsafe-inline'", () => {
+    it('skips the hashing of the scripts it finds', done => {
+      const webpackConfig = {
+        entry: path.join(__dirname, 'fixtures/index.js'),
+        output: {
+          path: OUTPUT_DIR,
+          filename: 'index.bundle.js'
+        },
+        mode: 'none',
+        plugins: [
+          new HtmlWebpackPlugin({
+            filename: path.join(OUTPUT_DIR, 'index.html'),
+            template: path.join(__dirname, 'fixtures', 'with-js.html'),
+            inject: 'body'
+          }),
+          new CspHtmlWebpackPlugin({
+            'base-uri': ["'self'", 'https://slack.com'],
+            'font-src': ["'self'", "'https://a-slack-edge.com'"],
+            'script-src': ["'self'", "'unsafe-inline'"],
+            'style-src': ["'self'"]
+          })
+        ]
+      };
+
+      testCspHtmlWebpackPlugin(
+        webpackConfig,
+        'index.html',
+        (cspPolicy, _, doneFn) => {
+          const expected =
+            "base-uri 'self' https://slack.com;" +
+            " object-src 'none';" +
+            " script-src 'self' 'unsafe-inline';" +
+            " style-src 'self';" +
+            " font-src 'self' 'https://a-slack-edge.com'";
+
+          expect(cspPolicy).toEqual(expected);
+
+          doneFn();
+        },
+        done
+      );
+    });
+  });
+
+  describe("when the user-specified style-src policy contains 'unsafe-inline'", () => {
+    it('skips the hashing of the styles it finds', done => {
+      const webpackConfig = {
+        entry: path.join(__dirname, 'fixtures/index.js'),
+        output: {
+          path: OUTPUT_DIR,
+          filename: 'index.bundle.js'
+        },
+        mode: 'none',
+        plugins: [
+          new HtmlWebpackPlugin({
+            filename: path.join(OUTPUT_DIR, 'index.html'),
+            template: path.join(__dirname, 'fixtures', 'with-css.html'),
+            inject: 'body'
+          }),
+          new CspHtmlWebpackPlugin({
+            'base-uri': ["'self'", 'https://slack.com'],
+            'font-src': ["'self'", "'https://a-slack-edge.com'"],
+            'script-src': ["'self'"],
+            'style-src': ["'self'", "'unsafe-inline'"]
+          })
+        ]
+      };
+
+      testCspHtmlWebpackPlugin(
+        webpackConfig,
+        'index.html',
+        (cspPolicy, _, doneFn) => {
+          const expected =
+            "base-uri 'self' https://slack.com;" +
+            " object-src 'none';" +
+            " script-src 'self';" +
+            " style-src 'self' 'unsafe-inline';" +
+            " font-src 'self' 'https://a-slack-edge.com'";
+
+          expect(cspPolicy).toEqual(expected);
+
+          doneFn();
+        },
+        done
+      );
+    });
+  });
+
   it('removes the empty Content Security Policy meta tag if enabled is the bool false', done => {
     const webpackConfig = {
       entry: path.join(__dirname, 'fixtures/index.js'),


### PR DESCRIPTION
###  Summary

Modern browsers ignore the `'unsafe-inline'` CSP setting [if any hash or nonce exists in that directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#Sources). This means that this plugin's automatic `sha256` hashes that it generates for inline scripts and styles implicitly disable `'unsafe-inline'` for modern browsers even if the developer explicitly wants `'unsafe-inline'` enabled.

This PR addresses the issue by adding an option to the plugin config to disable the implicit hashing. Setting `hashIfUnsafeInlinePresent` to `false` when initializing the plugin will make it skip hashing if a `script-src` or `style-src` directive contains an `'unsafe-inline'` value.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).
