### PR TITLE
feat: disable the plugin from HTMLWebpackPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This `CspHtmlWebpackPlugin` accepts 2 params with the following structure:
   * `{string}` hashingMethod - accepts 'sha256', 'sha384', 'sha512' - your node version must also accept this hashing method.
   * `{boolean|Function}` enabled - if false, or the function returns false, the empty CSP tag will be stripped from the html output. The `htmlPluginData` is passed into the function as it's first param.
 
+_Note: CSP usually runs on all files processed from HTML Webpack plugin, to disable it for a particular instance, set `disableCspPlugin` to `true(boolean)` in [HTML Webpack Plugins Options](https://github.com/jantimon/html-webpack-plugin#options)_
+
 #### Default Policy:
 
 ```

--- a/plugin.js
+++ b/plugin.js
@@ -4,6 +4,7 @@ const uniq = require('lodash/uniq');
 const compact = require('lodash/compact');
 const flatten = require('lodash/flatten');
 const isFunction = require('lodash/isFunction');
+const get = require('lodash/get');
 
 const defaultPolicy = {
   'base-uri': "'self'",
@@ -45,6 +46,15 @@ class CspHtmlWebpackPlugin {
    * @return {boolean} - whether the plugin is enabled or not
    */
   isEnabled(htmlPluginData) {
+    const disableCspPlugin = get(
+      htmlPluginData,
+      'plugin.options.disableCspPlugin'
+    );
+
+    if (disableCspPlugin && disableCspPlugin === true) {
+      return false;
+    }
+
     if (isFunction(this.opts.enabled)) {
       return this.opts.enabled(htmlPluginData);
     }

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -300,6 +300,37 @@ describe('CspHtmlWebpackPlugin', () => {
     );
   });
 
+  it('removes the empty Content Security Policy meta tag by setting `disableCspPlugin` in HTMLWebpack Plugin`s Options', done => {
+    const webpackConfig = {
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index.bundle.js'
+      },
+      mode: 'none',
+      plugins: [
+        new HtmlWebpackPlugin({
+          filename: path.join(OUTPUT_DIR, 'index.html'),
+          template: path.join(__dirname, 'fixtures', 'with-nothing.html'),
+          inject: 'body',
+          disableCspPlugin: true
+        }),
+        new CspHtmlWebpackPlugin()
+      ]
+    };
+
+    testCspHtmlWebpackPlugin(
+      webpackConfig,
+      'index.html',
+      (cspPolicy, $, doneFn) => {
+        expect(cspPolicy).toBeUndefined();
+        expect($('meta').length).toEqual(1);
+        doneFn();
+      },
+      done
+    );
+  });
+
   it('removes the empty Content Security Policy meta tag if enabled is a function which return false', done => {
     const webpackConfig = {
       entry: path.join(__dirname, 'fixtures/index.js'),


### PR DESCRIPTION
###  Summary

Hi,

This should disable the plugin from htmlwebpackplugin. this comes handy in a very large applications where CSP plugin is not expected to add meta tags for particular/few html files

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).
