### PR TITLE
An option for disabling unsafe inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Finally, add the following tag to your HTML template where you would like to add
 This `CspHtmlWebpackPlugin` accepts 2 params with the following structure:
 * `{object}` Policy (optional) - a flat object which defines your CSP policy. Valid keys and values can be found on the [MDN CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) page. Values can either be a string or an array of strings.
 * `{object}` Additional Options (optional) - a flat object with the optional configuration options:
-  * `{string}` hashingMethod - accepts 'sha256', 'sha384', 'sha512' - your node version must also accept this hashing method.
+  * `{boolean}` devAllowUnsafe - if you as the developer want to allow `unsafe-inline`/`unsafe-eval` and _not_ include hashes for inline scripts. If any hashes are included in the policy, modern browsers ignore the `unsafe-inline` rule.
   * `{boolean|Function}` enabled - if false, or the function returns false, the empty CSP tag will be stripped from the html output. The `htmlPluginData` is passed into the function as it's first param.
+  * `{string}` hashingMethod - accepts 'sha256', 'sha384', 'sha512' - your node version must also accept this hashing method.
 
-_Note: CSP usually runs on all files processed from HTML Webpack plugin, to disable it for a particular instance, set `disableCspPlugin` to `true(boolean)` in [HTML Webpack Plugins Options](https://github.com/jantimon/html-webpack-plugin#options)_
+_Note: CSP runs on all files created by HTMLWebpackPlugin. You can disable it for a particular instance by setting `disableCspPlugin` to `true` in the HTMLWebpackPlugin options
 
 #### Default Policy:
 
@@ -59,8 +60,9 @@ _Note: CSP usually runs on all files processed from HTML Webpack plugin, to disa
 
 ```
 {
-  hashingMethod: 'sha256',
+  devAllowUnsafe: false,
   enabled: true
+  hashingMethod: 'sha256',
 }
 ```
 
@@ -72,8 +74,9 @@ new CspHtmlWebpackPlugin({
   'script-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"],
   'style-src': ["'unsafe-inline'", "'self'", "'unsafe-eval'"]
 }, {
-  hashingMethod: 'sha256',
+  devAllowUnsafe: false,
   enabled: true
+  hashingMethod: 'sha256',
 })
 ```
 


### PR DESCRIPTION
###  Summary

Previously, we added functionality to not generate hashes if `unsafe-inline` was specifically added to a policy by a developer, however, this breaks csp backwards compatibility with older browsers.

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src):
> Specifying nonce makes a modern browser ignore 'unsafe-inline' which could still be set for older browsers without nonce support

The same applies to hashes

This PR has added in a new config option (`devAllowUnsafe`) to allow the developer to stop inline hash processing if set. Otherwise, a policy will be created with both `unsafe-inline` and inline script hashes

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).
