### PR TITLE
Adding HtmlWebpackPlugin@4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "webpack": "^2 || ^3 || ^4",
-    "html-webpack-plugin": "^2 || ^3"
+    "html-webpack-plugin": "^2 || ^3 || ^4"
   },
   "devDependencies": {
     "codecov": "^3.1.0",


### PR DESCRIPTION
###  Summary

Building off of PR https://github.com/slackhq/csp-html-webpack-plugin/pull/16/, this PR adds HtmlWebpackPlugin@4 support to the CspHtmlWebpackPlugin.

Opted to move the require to the top of the file to ensure we load it once and reference it - also keeps the requires a little more together for easier debugging.

Credits go to @sibiraj-s for the initial implementation in the PR linked above

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).
