### PR TITLE
Adding nonce attrs to external scripts where their host hasnt been defined in the CSP already

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eslint": "eslint .",
     "eslint:fix": "eslint . --fix",
     "jest": "jest --config=./jest.config.js plugin.jest.js",
-    "jest:watch": "jest --watch --config=./jest.config.js plugin.jest.js",
+    "jest:watch": "jest --watch --verbose=false --config=./jest.config.js plugin.jest.js",
     "jest:coverage:generate": "jest --coverage --config=./jest.config.js plugin.jest.js",
     "jest:coverage:clean": "rm -rf ./coverage",
     "jest:coverage:upload": "npx codecov --token=252086ef-c14d-4f29-ab36-720265249fa2",

--- a/test-utils/webpack-helpers.js
+++ b/test-utils/webpack-helpers.js
@@ -58,14 +58,16 @@ function webpackCompile(webpackConfig, callbackFn, { fs = null } = {}) {
 /**
  * Helper to create a basic webpack config which can then be used in the compile function
  * @param plugins[] - array of plugins to pass into webpack
+ * @param {string} publicPath - publicPath setting for webpack
  * @return {{mode: string, output: {path: string, filename: string}, entry: string, plugins: *}}
  */
-function createWebpackConfig(plugins) {
+function createWebpackConfig(plugins, publicPath = undefined) {
   return {
     mode: 'none',
     entry: path.join(__dirname, '..', 'test-utils', 'fixtures', 'index.js'),
     output: {
       path: WEBPACK_OUTPUT_DIR,
+      publicPath,
       filename: 'index.bundle.js'
     },
     plugins


### PR DESCRIPTION
###  Summary

Nonce attributes will now be added to external scripts and styles whos hostnames haven't been defined in the CSP policy already. If, however, you add your public path to your CSP policy, a nonce won't be added for that specific script tag.

Before merging this, we should check to see if [`strict-dynamic`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic) exists in the policy - if it does, we will still need to generate nonce ids for all external assets, even if their host has been allowed in the CSP policy

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).
