### PR TITLE
If plugin is disabled, we should not modify the html at all

### DIFF
--- a/plugin.jest.js
+++ b/plugin.jest.js
@@ -508,7 +508,7 @@ describe('CspHtmlWebpackPlugin', () => {
   });
 
   describe('Enabled check', () => {
-    it('removes the empty Content Security Policy meta tag if enabled is the bool false', done => {
+    it("doesn't modify the html if enabled is the bool false", done => {
       const config = createWebpackConfig([
         new HtmlWebpackPlugin({
           filename: path.join(WEBPACK_OUTPUT_DIR, 'index.html'),
@@ -516,7 +516,7 @@ describe('CspHtmlWebpackPlugin', () => {
             __dirname,
             'test-utils',
             'fixtures',
-            'with-nothing.html'
+            'with-no-meta-tag.html'
           )
         }),
         new CspHtmlWebpackPlugin(
@@ -534,7 +534,7 @@ describe('CspHtmlWebpackPlugin', () => {
       });
     });
 
-    it('removes the empty Content Security Policy meta tag if the `cspPlugin.disabled` option in HtmlWebpack Plugin is true', done => {
+    it("doesn't modify the html if the `cspPlugin.enabled` option in HtmlWebpack Plugin is false", done => {
       const config = createWebpackConfig([
         new HtmlWebpackPlugin({
           filename: path.join(WEBPACK_OUTPUT_DIR, 'index.html'),
@@ -542,7 +542,7 @@ describe('CspHtmlWebpackPlugin', () => {
             __dirname,
             'test-utils',
             'fixtures',
-            'with-nothing.html'
+            'with-no-meta-tag.html'
           ),
           cspPlugin: {
             enabled: false
@@ -558,7 +558,7 @@ describe('CspHtmlWebpackPlugin', () => {
       });
     });
 
-    it('removes the empty Content Security Policy meta tag if enabled is a function which return false', done => {
+    it("doesn't modify the html if enabled is a function which return false", done => {
       const config = createWebpackConfig([
         new HtmlWebpackPlugin({
           filename: path.join(WEBPACK_OUTPUT_DIR, 'index.html'),
@@ -566,7 +566,7 @@ describe('CspHtmlWebpackPlugin', () => {
             __dirname,
             'test-utils',
             'fixtures',
-            'with-nothing.html'
+            'with-no-meta-tag.html'
           )
         }),
         new CspHtmlWebpackPlugin(
@@ -584,7 +584,7 @@ describe('CspHtmlWebpackPlugin', () => {
       });
     });
 
-    it('only removes the Content Security Policy meta tag from the HtmlWebpackPlugin instance which has been disabled', done => {
+    it("doesn't modify html from the HtmlWebpackPlugin instance which has been disabled", done => {
       const config = createWebpackConfig([
         new HtmlWebpackPlugin({
           filename: path.join(WEBPACK_OUTPUT_DIR, 'index-enabled.html'),
@@ -592,7 +592,7 @@ describe('CspHtmlWebpackPlugin', () => {
             __dirname,
             'test-utils',
             'fixtures',
-            'with-nothing.html'
+            'with-no-meta-tag.html'
           )
         }),
         new HtmlWebpackPlugin({
@@ -601,7 +601,7 @@ describe('CspHtmlWebpackPlugin', () => {
             __dirname,
             'test-utils',
             'fixtures',
-            'with-nothing.html'
+            'with-no-meta-tag.html'
           ),
           cspPlugin: {
             enabled: false

--- a/plugin.js
+++ b/plugin.js
@@ -282,17 +282,12 @@ class CspHtmlWebpackPlugin {
       decodeEntities: false
     });
 
-    let metaTag = $('meta[http-equiv="Content-Security-Policy"]');
-
     // if not enabled, remove the empty tag
     if (!this.isEnabled(htmlPluginData)) {
-      metaTag.remove();
-
-      // eslint-disable-next-line no-param-reassign
-      htmlPluginData.html = $.html();
-
       return compileCb(null, htmlPluginData);
     }
+
+    let metaTag = $('meta[http-equiv="Content-Security-Policy"]');
 
     // Add element if it doesn't exist.
     if (!metaTag.length) {


### PR DESCRIPTION
###  Summary

When a CSP plugin instance is disabled, we should not modify the HTML at all, as proposed in this PR comment: https://github.com/slackhq/csp-html-webpack-plugin/pull/16#issuecomment-444726998

This means that cheerio won't add empty HTML tags to the file it is modifying, potentially causing incorrect HTML markup

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).
