### PR TITLE
Ensuring that html webpack plugin hooks are available

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -357,7 +357,10 @@ class CspHtmlWebpackPlugin {
             'CspHtmlWebpackPlugin',
             this.processCsp.bind(this)
           );
-        } else {
+        } else if (
+          compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration &&
+          compilation.hooks.htmlWebpackPluginAfterHtmlProcessing
+        ) {
           // HTMLWebpackPlugin@3
           compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tapAsync(
             'CspHtmlWebpackPlugin',


### PR DESCRIPTION
###  Summary

Ensuring that html webpack plugin hooks are available before attempting to register callbacks on hooks - if html webpack plugin has not been defined, this will error out

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).
