### PR TITLE
Add new output callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This `CspHtmlWebpackPlugin` accepts 2 params with the following structure:
   - `{string}` hashingMethod - accepts 'sha256', 'sha384', 'sha512' - your node version must also accept this hashing method.
   - `{object}` hashEnabled - a `<string, boolean>` entry for which policy rules are allowed to include hashes
   - `{object}` nonceEnabled - a `<string, boolean>` entry for which policy rules are allowed to include nonces
+  - `{Function}` output (optional) - optional callback function receiving the computed CSP policy to implement custom logic instead of including meta tag.
 
 The plugin also adds a new config option onto each `HtmlWebpackPlugin` instance:
 

--- a/plugin.jest.js
+++ b/plugin.jest.js
@@ -852,4 +852,29 @@ describe('CspHtmlWebpackPlugin', () => {
       });
     });
   });
+
+  describe.only('Plugin output callback', () => {
+    it("doesn't modify the html if enabled is the bool false", done => {
+      // eslint-disable-next-line no-unused-vars
+      const mockCallback = jest.fn(csp => {});
+      const config = createWebpackConfig([
+        new HtmlWebpackPlugin({
+          filename: path.join(WEBPACK_OUTPUT_DIR, 'index.html')
+        }),
+        new CspHtmlWebpackPlugin({}, { output: mockCallback })
+      ]);
+
+      webpackCompile(config, csps => {
+        const expected =
+          "base-uri 'self';" +
+          " object-src 'none';" +
+          " script-src 'unsafe-inline' 'self' 'unsafe-eval' 'nonce-mockedbase64string-1';" +
+          " style-src 'unsafe-inline' 'self' 'unsafe-eval'";
+
+        expect(mockCallback).toBeCalledWith(expected);
+        expect(csps['index.html']).not.toEqual(expected);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
###  Summary

Adding a new `output` callback function passing the computed CSP rules to execute custom logic.

Our team is interested to add CSP policy, but we want to add it as HTTP header instead of  `meta` tag. This enables the capability to use `frame-ancestors`, report-uri, or `sandbox` not available with `meta` tag.

Right now, the rule is automatically added as `meta` tag. To be able to add it as HTTP header, we need to compute the rule by `csp-html-webpack-plugin` and pass it to a custom function to use it for example by Nginx.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/csp-html-webpack-plugin).

