### PR TITLE
Add webpack compilation object to processfn

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,15 @@ new CspHtmlWebpackPlugin({
 })
 ```
 ## Advanced Usage
-### Dumping the CSP directives into a file
+### Generating a file containing the CSP directives
 
-Sometimes the `<meta>` tag is not compatible with specific directives, for example `report-uri` or `report-to`.
-For that specific case, it's possible to set your own `processFn` callback to add a conf file that will be used by the reverse-proxy.
+Some specific directives require the CSP to be sent to the client via a response header (e.g. `report-uri` and `report-to`)
+You can set your own `processFn` callback to make this happen.
 
-Here is an example for nginx in webpack.config.js : 
+#### nginx
+
+In your webpack config:
+
 ```js
 const RawSource = require('webpack-sources').RawSource;
 
@@ -230,8 +233,7 @@ module.exports = {
   ]
 };
 ```
-
-In nginx configuration :
+In your nginx config:
 ```nginx
 location / {
   ...

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This `CspHtmlWebpackPlugin` accepts 2 params with the following structure:
       - `builtPolicy`: a `string` containing the completed policy;
       - `htmlPluginData`: the `HtmlWebpackPlugin` `object`;
       - `$`: the `cheerio` object of the html file currently being processed
+      - `compilation`: Internal webpack object to manipulate the build
 
 ### `HtmlWebpackPlugin`
 
@@ -105,6 +106,7 @@ The plugin also adds a new config option onto each `HtmlWebpackPlugin` instance:
       - `builtPolicy`: a `string` containing the completed policy;
       - `htmlPluginData`: the `HtmlWebpackPlugin` `object`;
       - `$`: the `cheerio` object of the html file currently being processed
+      - `compilation`: Internal webpack object to manipulate the build
 
 ### Order of Precedence:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ All inline JS and CSS will be hashed and inserted into the policy.
 
 Install the plugin with npm:
 
-```
+```bash
 npm i --save-dev csp-html-webpack-plugin
 ```
 
@@ -25,7 +25,7 @@ npm i --save-dev csp-html-webpack-plugin
 
 Include the following in your webpack config:
 
-```
+```js
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CspHtmlWebpackPlugin = require('csp-html-webpack-plugin');
 
@@ -127,7 +127,7 @@ In the case where a config object is defined in multiple places, it will be merg
 
 #### Default Policy:
 
-```
+```js
 {
   'base-uri': "'self'",
   'object-src': "'none'",
@@ -138,7 +138,7 @@ In the case where a config object is defined in multiple places, it will be merg
 
 #### Default Additional Options:
 
-```
+```js
 {
   enabled: true
   hashingMethod: 'sha256',
@@ -156,7 +156,7 @@ In the case where a config object is defined in multiple places, it will be merg
 
 #### Full Default Configuration:
 
-```
+```js
 new HtmlWebpackPlugin({
   cspPlugin: {
     enabled: true,
@@ -197,7 +197,47 @@ new CspHtmlWebpackPlugin({
   processFn: defaultProcessFn  // defined in the plugin itself
 })
 ```
+## Advanced Usage
+### Dumping the CSP directives into a file
 
+Sometimes the `<meta>` tag is not compatible with specific directives, for example `report-uri` or `report-to`.
+For that specific case, it's possible to set your own `processFn` callback to add a conf file that will be used by the reverse-proxy.
+
+Here is an example for nginx in webpack.config.js : 
+```js
+const RawSource = require('webpack-sources').RawSource;
+
+function generateNginxHeaderFile(
+  builtPolicy,
+  _htmlPluginData,
+  _obj,
+  compilation
+) {
+  const header =
+    'add_header Content-Security-Policy "' +
+    builtPolicy +
+    '; report-uri /csp-report/ ";';
+  compilation.emitAsset('nginx-csp-header.conf', new RawSource(header));
+}
+
+module.exports = {
+  {...},
+  plugins: [
+    new CspHtmlWebpackPlugin(
+      {...}, {
+      processFn: generateNginxHeaderFile
+    })
+  ]
+};
+```
+
+In nginx configuration :
+```nginx
+location / {
+  ...
+  include /path/to/webpack/output/nginx-csp-header.conf
+}
+```
 ## Contribution
 
 Contributions are most welcome! Please see the included contributing file for more information.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jest": "^26.6.3",
     "memory-fs": "^0.5.0",
     "prettier": "^2.2.1",
-    "webpack": "^5.10.1"
+    "webpack": "^5.10.1",
+    "webpack-sources": "^2.2.0"
   }
 }

--- a/plugin.jest.js
+++ b/plugin.jest.js
@@ -885,6 +885,7 @@ describe('CspHtmlWebpackPlugin', () => {
         expect(processFn).toHaveBeenCalledWith(
           builtPolicy,
           expect.anything(),
+          expect.anything(),
           expect.anything()
         );
 
@@ -931,6 +932,7 @@ describe('CspHtmlWebpackPlugin', () => {
         // index-1.html should have used our custom function defined
         expect(processFn).toHaveBeenCalledWith(
           index1BuiltPolicy,
+          expect.anything(),
           expect.anything(),
           expect.anything()
         );

--- a/plugin.js
+++ b/plugin.js
@@ -311,7 +311,7 @@ class CspHtmlWebpackPlugin {
    * @param htmlPluginData
    * @param compileCb
    */
-  processCsp(htmlPluginData, compileCb) {
+  processCsp(compilation, htmlPluginData, compileCb) {
     const $ = cheerio.load(htmlPluginData.html, {
       decodeEntities: false,
       _useHtmlParser2: true,
@@ -343,7 +343,7 @@ class CspHtmlWebpackPlugin {
       ),
     });
 
-    this.processFn(builtPolicy, htmlPluginData, $);
+    this.processFn(builtPolicy, htmlPluginData, $, compilation);
 
     return compileCb(null, htmlPluginData);
   }
@@ -360,7 +360,7 @@ class CspHtmlWebpackPlugin {
       );
       HtmlWebpackPlugin.getHooks(compilation).beforeEmit.tapAsync(
         'CspHtmlWebpackPlugin',
-        this.processCsp.bind(this)
+        this.processCsp.bind(this, compilation)
       );
     });
   }


### PR DESCRIPTION
###  Summary

Enables to manipulate the webpack build to add an asset file to the build.
Discussed in https://github.com/slackhq/csp-html-webpack-plugin/issues/52


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/hack-json-schema).
