### PR TITLE
Change Jest configuration to also work on Windows

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   displayName: 'CspHtmlWebpackPlugin',
   roots: ['<rootDir>'],
-  testMatch: ['<rootDir>/?(*.)jest.js'],
+  testMatch: ['**/*.jest.js'],
   testPathIgnorePatterns: ['/node_modules/'],
   clearMocks: true,
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "jest": "jest --config=./jest.config.js plugin.jest.js",
     "jest:watch": "jest --watch --verbose=false --config=./jest.config.js plugin.jest.js",
     "jest:coverage:generate": "jest --coverage --config=./jest.config.js plugin.jest.js",
-    "jest:coverage:clean": "rm -rf ./coverage",
+    "jest:coverage:clean": "rimraf ./coverage",
     "jest:coverage:upload": "npx codecov",
     "jest:coverage": "npm run jest:coverage:clean && npm run jest:coverage:generate && npm run jest:coverage:upload",
     "test": "npm run eslint && npm run jest && npm run jest:coverage"
@@ -48,6 +48,7 @@
     "jest": "^26.6.3",
     "memory-fs": "^0.5.0",
     "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
     "webpack": "^5.10.1",
     "webpack-sources": "^2.2.0"
   }


### PR DESCRIPTION
###  Summary

Due to Windows file paths, jest wasn't able to find any test files
and due to rm not being available on Windows, coverage could
not be created.

Updating the test matcher and replacing rm with rimraf (a node dependency)
allows Windows to run this project properly when developing locally
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/hack-json-schema).
