### PR TITLE
Support upgrade-insecure-requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This `CspHtmlWebpackPlugin` accepts 2 params with the following structure:
       - `htmlPluginData`: the `HtmlWebpackPlugin` `object`;
       - `$`: the `cheerio` object of the html file currently being processed
       - `compilation`: Internal webpack object to manipulate the build
+  - `{boolean}` upgradeInsecureRequests - if true, `upgrade-insecure-requests` will be added to the CSP tag.
 
 ### `HtmlWebpackPlugin`
 
@@ -107,6 +108,7 @@ The plugin also adds a new config option onto each `HtmlWebpackPlugin` instance:
       - `htmlPluginData`: the `HtmlWebpackPlugin` `object`;
       - `$`: the `cheerio` object of the html file currently being processed
       - `compilation`: Internal webpack object to manipulate the build
+  - `{boolean}` upgradeInsecureRequests - if true, [upgrade-insecure-requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests) will be added to the CSP tag.
 
 ### Order of Precedence:
 
@@ -150,7 +152,8 @@ In the case where a config object is defined in multiple places, it will be merg
     'script-src': true,
     'style-src': true
   },
-  processFn: defaultProcessFn
+  processFn: defaultProcessFn,
+  upgradeInsecureRequests: false
 }
 ```
 
@@ -174,7 +177,8 @@ new HtmlWebpackPlugin({
       'script-src': true,
       'style-src': true
     },
-    processFn: defaultProcessFn  // defined in the plugin itself
+    processFn: defaultProcessFn,  // defined in the plugin itself
+    upgradeInsecureRequests: false
   }
 });
 
@@ -194,7 +198,8 @@ new CspHtmlWebpackPlugin({
     'script-src': true,
     'style-src': true
   },
-  processFn: defaultProcessFn  // defined in the plugin itself
+  processFn: defaultProcessFn,  // defined in the plugin itself
+  upgradeInsecureRequests: false
 })
 ```
 ## Advanced Usage

--- a/plugin.jest.js
+++ b/plugin.jest.js
@@ -155,13 +155,18 @@ describe('CspHtmlWebpackPlugin', () => {
             'with-nothing.html'
           ),
         }),
-        new CspHtmlWebpackPlugin({
-          'base-uri': ["'self'", 'https://slack.com'],
-          'font-src': ["'self'", "'https://a-slack-edge.com'"],
-          'script-src': ["'self'"],
-          'style-src': ["'self'"],
-          'connect-src': ["'self'"],
-        }),
+        new CspHtmlWebpackPlugin(
+          {
+            'base-uri': ["'self'", 'https://slack.com'],
+            'font-src': ["'self'", "'https://a-slack-edge.com'"],
+            'script-src': ["'self'"],
+            'style-src': ["'self'"],
+            'connect-src': ["'self'"],
+          },
+          {
+            upgradeInsecureRequests: true,
+          }
+        ),
       ]);
 
       webpackCompile(config, (csps) => {
@@ -171,7 +176,8 @@ describe('CspHtmlWebpackPlugin', () => {
           " script-src 'self' 'nonce-mockedbase64string-1';" +
           " style-src 'self';" +
           " font-src 'self' 'https://a-slack-edge.com';" +
-          " connect-src 'self'";
+          " connect-src 'self';" +
+          ' upgrade-insecure-requests';
 
         expect(csps['index.html']).toEqual(expected);
         done();

--- a/plugin.js
+++ b/plugin.js
@@ -65,6 +65,7 @@ const defaultAdditionalOpts = {
     'style-src': true,
   },
   processFn: defaultProcessFn,
+  upgradeInsecureRequests: false,
 };
 
 class CspHtmlWebpackPlugin {
@@ -286,24 +287,28 @@ class CspHtmlWebpackPlugin {
    */
   // eslint-disable-next-line class-methods-use-this
   buildPolicy(policyObj) {
-    return Object.keys(policyObj)
-      .map((key) => {
-        const val = Array.isArray(policyObj[key])
-          ? compact(uniq(policyObj[key])).join(' ')
-          : policyObj[key];
+    const policy = Object.keys(policyObj).map((key) => {
+      const val = Array.isArray(policyObj[key])
+        ? compact(uniq(policyObj[key])).join(' ')
+        : policyObj[key];
 
-        // move strict dynamic to the end of the policy if it exists to be backwards compatible with csp2
-        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic
-        if (val.includes("'strict-dynamic'")) {
-          const newVal = `${val
-            .replace(/\s?'strict-dynamic'\s?/gi, ' ')
-            .trim()} 'strict-dynamic'`;
-          return `${key} ${newVal}`;
-        }
+      // move strict dynamic to the end of the policy if it exists to be backwards compatible with csp2
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic
+      if (val.includes("'strict-dynamic'")) {
+        const newVal = `${val
+          .replace(/\s?'strict-dynamic'\s?/gi, ' ')
+          .trim()} 'strict-dynamic'`;
+        return `${key} ${newVal}`;
+      }
 
-        return `${key} ${val}`;
-      })
-      .join('; ');
+      return `${key} ${val}`;
+    });
+
+    if (this.opts.upgradeInsecureRequests) {
+      policy.push('upgrade-insecure-requests');
+    }
+
+    return policy.join('; ');
   }
 
   /**


### PR DESCRIPTION
###  Summary

Add support for `upgrade-insecure-requests` ([details](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests)).

As it's a directive without values (it's either present, or it's not) it didn't feel right to add it to the regular directives as it would require quite a bit of code changes to support Boolean directives, so I decided to add it to the additional options.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/csp-html-webpack-plugin/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [X] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/hack-json-schema).
